### PR TITLE
Improve and fix typos in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- composer req @dev in README for development.
 
 ## [0.0.1] - 2020-12-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.0.2] - 2020-12-18
 ### Fixed
-- composer req @dev in README for development.
+- composer req @dev in README.
+- git clone url in README.
+### Added
+- Better explanation in the "Wrong wildcard certificate" section.
 
 ## [0.0.1] - 2020-12-14
 ### Added

--- a/README.md
+++ b/README.md
@@ -79,12 +79,12 @@ Expiration dates for included content:
 
 As standalone tool:
 ```
-git clone github.com:masfernandez/nginx-proxy-local-development.git
+git clone https://github.com/masfernandez/nginx-proxy-local-development.git
 ```
 
 As composer dependency:
 ```
-composer req masfernandez/nginx-proxy-local-development
+composer req --dev masfernandez/nginx-proxy-local-development:dev-master
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ I created this repository to speed up the initial configuration of local develop
 In combination with services such as xip.io (What is xip.io? please read documentation here: [http://xip.io](http://xip.io)), allows also:
 
 - No more /etc/hosts file editing
-- Develop and test local applications from external hosts without complicated configurations
-- Free alternative to Ngrok, Serveo, etc.
+- Develop and test several local applications (webservers) from external hosts without complicated configurations
+- Free alternative to Ngrok, Serveo, etc. (require some NAT configuration on router)
 
 
 
@@ -100,11 +100,11 @@ In short, that subdomain will resolve to your local computer without editing /et
 ping backend.127.0.0.1.xip.io
 ```
 
-If you prefer using your custom SLD like my-cool-app.com instead &lt;whatever&gt;.xip.io, you can also use this repo to generate your own custom CA and certs. El principal inconveniente de esto es que tendrás que apuntar my-cool-app.com a la 127.0.0.1 IP editando el archivo /etc/hosts. Choosing this way I recommend using [Gas Mask](https://github.com/2ndalpha/gasmask).
+If you prefer using your custom SLD like my-cool-app.com instead &lt;whatever&gt;.xip.io, you can also use this repo to generate your own custom CA and certs. The main drawback of this is that you will have to point my-cool-app.com to the 127.0.0.1 IP by editing the /etc/hosts file. Choosing this way I recommend using [Gas Mask](https://github.com/2ndalpha/gasmask).
 
 ### Fast usage as standalone tool
 
-Configure Nginx vhost example located in docker/nginx/conf.d/backend.127.0.0.1.xip.io.conf as your needs.
+Configure the Nginx vhost example located in docker/nginx/conf.d/backend.127.0.0.1.xip.io.conf as your needs.
 
 That vhost example is using:
 - Subdomain: backend.127.0.0.1.xip.io
@@ -172,7 +172,7 @@ Create a docker-compose.yml file in the root of your project or integrate bellow
       - ./vendor/masfernandez/nginx-proxy-local-development/docker/nginx/conf.d:/etc/nginx/conf.d:ro
 ```
 
-Show full example file:
+Full example docker-compose.yml file for your reference:
 ```
 cat vendor/masfernandez/nginx-proxy-local-development/docker-compose-example-proxy.yml
 ```
@@ -259,7 +259,11 @@ Valid for domains like web.my-new-site.com, backend.my-new-site.com, etc.
 ````
 ./gen-cert.sh wildcard.xip.io
 ````
-Because: [Stackoverflow](https://serverfault.com/questions/933374/can-a-wildcard-ssl-certificate-secure-host-names-of-various-depths)
+Actually is not wrong at all, but this depth level of wildcard is destined to configure the host IP to resolve on xip.io DNS, like for example 192.168.1.10.xip.io will resolve at 192.168.1.1 IP on your local network.
+
+Using the above wildcard certificate you will have to run each webserver on a different IP of your network. We want all webservers availables at locahost for development. 
+
+Explanation here: [Stackoverflow](https://serverfault.com/questions/933374/can-a-wildcard-ssl-certificate-secure-host-names-of-various-depths)
 
 
 ### Validate cert


### PR DESCRIPTION
### Fixed
- composer req @dev in README.
- git clone url in README.
### Added
- Better explanation in the "Wrong wildcard certificate" section.